### PR TITLE
feat(api): add user, room, message models and endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ backend/.env
 frontend/.env.local
 frontend/node_modules/
 frontend/.next/
+backend/app.db

--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -1,0 +1,35 @@
+[alembic]
+script_location = migrations
+sqlalchemy.url = sqlite:///app.db
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,17 +1,40 @@
+import datetime as dt
 import os
 
-from flask import Flask, jsonify
+from flask import Flask, jsonify, g, request, session as ws_session
 from flask_cors import CORS
 from flask_jwt_extended import JWTManager
-from flask_socketio import Namespace, SocketIO
+from flask_socketio import Namespace, SocketIO, join_room, leave_room
+
+from backend.app.auth import bp as auth_bp
+from backend.app.rooms import bp as rooms_bp
+from backend.app.models import SessionLocal, Message, Room
 
 app = Flask(__name__)
 app.config.setdefault("JWT_SECRET_KEY", os.environ.get("JWT_SECRET_KEY", "change-me"))
 app.config.setdefault("CORS_ORIGIN", os.environ.get("CORS_ORIGIN", "http://localhost:3000"))
+app.config.setdefault("DATABASE_URL", os.environ.get("DATABASE_URL", "sqlite:///app.db"))
 
 CORS(app, origins=app.config["CORS_ORIGIN"], supports_credentials=True)
 jwt = JWTManager(app)
-socketio = SocketIO(app, cors_allowed_origins=app.config["CORS_ORIGIN"]) 
+socketio = SocketIO(app, cors_allowed_origins=app.config["CORS_ORIGIN"])
+
+app.register_blueprint(auth_bp)
+app.register_blueprint(rooms_bp)
+
+
+@app.before_request
+def create_session():
+    g.db = SessionLocal()
+
+
+@app.teardown_request
+def remove_session(exc=None):
+    db = g.pop("db", None)
+    if db is not None:
+        if exc:
+            db.rollback()
+        db.close()
 
 
 @app.get("/healthz")
@@ -22,11 +45,83 @@ def healthz():
 class WSNamespace(Namespace):
     namespace = "/ws"
 
-    def on_connect(self):
-        pass
+    def _ack(self, event: str, ok: bool = True, data=None, code=None, message=None, details=None):
+        if ok:
+            return {
+                "ok": True,
+                "event": event,
+                "ts": dt.datetime.utcnow().isoformat() + "Z",
+                "data": data or {},
+            }
+        return {
+            "ok": False,
+            "event": event,
+            "code": code or "ERROR",
+            "message": message or "",
+            "details": details or {},
+        }
 
-    def on_disconnect(self):
-        pass
+    def on_connect(self):
+        token = request.args.get("token")
+        if not token:
+            auth = request.headers.get("Authorization", "")
+            if auth.startswith("Bearer "):
+                token = auth.split(" ", 1)[1]
+        if not token:
+            return False
+        try:
+            data = jwt.decode_token(token)
+        except Exception:  # pragma: no cover - token invalid
+            return False
+        ws_session["user_id"] = data["sub"]
+
+    def on_room_join(self, data):
+        room_id = data.get("roomId") if data else None
+        if not room_id:
+            return self._ack("room:join", ok=False, code="PAYLOAD_INVALID", message="roomId required")
+        join_room(room_id)
+        return self._ack("room:join", data={"roomId": room_id})
+
+    def on_room_leave(self, data):
+        room_id = data.get("roomId") if data else None
+        if not room_id:
+            return self._ack("room:leave", ok=False, code="PAYLOAD_INVALID", message="roomId required")
+        leave_room(room_id)
+        return self._ack("room:leave", data={"roomId": room_id})
+
+    def on_message_create(self, data):
+        room_id = data.get("roomId") if data else None
+        body = data.get("body") if data else None
+        if not room_id or not body:
+            return self._ack("message:create", ok=False, code="PAYLOAD_INVALID", message="roomId and body required")
+        session = SessionLocal()
+        room = session.get(Room, room_id)
+        if not room:
+            session.close()
+            return self._ack("message:create", ok=False, code="ROOM_NOT_FOUND", message="Room not found")
+        msg = Message(room_id=room_id, user_id=ws_session.get("user_id"), body=body)
+        session.add(msg)
+        session.commit()
+        payload = {
+            "id": msg.id,
+            "roomId": msg.room_id,
+            "userId": msg.user_id,
+            "body": msg.body,
+            "createdAt": msg.created_at.isoformat(),
+            "editedAt": None,
+        }
+        self.emit("message:new", payload, room=room_id)
+        session.close()
+        return self._ack("message:create", data={"id": msg.id, "roomId": msg.room_id})
+
+    def on_message_typing(self, data):
+        room_id = data.get("roomId") if data else None
+        if not room_id:
+            return self._ack("message:typing", ok=False, code="PAYLOAD_INVALID", message="roomId required")
+        is_typing = bool(data.get("isTyping")) if data else False
+        payload = {"roomId": room_id, "userId": ws_session.get("user_id"), "isTyping": is_typing}
+        self.emit("message:typing", payload, room=room_id, include_self=False)
+        return self._ack("message:typing", data={"roomId": room_id, "isTyping": is_typing})
 
 
 socketio.on_namespace(WSNamespace(WSNamespace.namespace))

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,0 +1,1 @@
+# Flask application package

--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -1,0 +1,42 @@
+from uuid import uuid4
+
+from flask import Blueprint, g, jsonify, request
+from sqlalchemy.exc import IntegrityError
+from werkzeug.security import check_password_hash, generate_password_hash
+from flask_jwt_extended import create_access_token
+
+from .models import User
+
+bp = Blueprint("auth", __name__, url_prefix="/auth")
+
+
+@bp.post("/signup")
+def signup():
+    data = request.get_json() or {}
+    email = data.get("email")
+    password = data.get("password")
+    display_name = data.get("displayName")
+    if not email or not password or not display_name:
+        return jsonify({"message": "Invalid payload"}), 400
+    session = g.db
+    user = User(id=str(uuid4()), email=email, password_hash=generate_password_hash(password), display_name=display_name)
+    session.add(user)
+    try:
+        session.commit()
+    except IntegrityError:
+        session.rollback()
+        return jsonify({"message": "Email already used"}), 400
+    return ("", 201)
+
+
+@bp.post("/login")
+def login():
+    data = request.get_json() or {}
+    email = data.get("email")
+    password = data.get("password")
+    session = g.db
+    user = session.query(User).filter_by(email=email).first()
+    if not user or not check_password_hash(user.password_hash, password):
+        return jsonify({"message": "Invalid credentials"}), 401
+    token = create_access_token(identity=user.id)
+    return jsonify({"accessToken": token})

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,0 +1,55 @@
+import os
+import datetime as dt
+from uuid import uuid4
+
+from sqlalchemy import DateTime, ForeignKey, String, Text, create_engine
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship, sessionmaker, scoped_session
+
+DATABASE_URL = os.environ.get("DATABASE_URL", "sqlite:///app.db")
+
+engine = create_engine(DATABASE_URL, future=True)
+SessionLocal = scoped_session(sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True))
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+def generate_uuid() -> str:
+    return str(uuid4())
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id: Mapped[str] = mapped_column(String, primary_key=True, default=generate_uuid)
+    email: Mapped[str] = mapped_column(String, unique=True, nullable=False)
+    password_hash: Mapped[str] = mapped_column(String, nullable=False)
+    display_name: Mapped[str] = mapped_column(String, nullable=False)
+    created_at: Mapped[dt.datetime] = mapped_column(DateTime, default=dt.datetime.utcnow)
+
+    messages = relationship("Message", back_populates="user")
+
+
+class Room(Base):
+    __tablename__ = "rooms"
+
+    id: Mapped[str] = mapped_column(String, primary_key=True, default=generate_uuid)
+    name: Mapped[str] = mapped_column(String, nullable=False)
+    created_at: Mapped[dt.datetime] = mapped_column(DateTime, default=dt.datetime.utcnow)
+
+    messages = relationship("Message", back_populates="room")
+
+
+class Message(Base):
+    __tablename__ = "messages"
+
+    id: Mapped[str] = mapped_column(String, primary_key=True, default=generate_uuid)
+    room_id: Mapped[str] = mapped_column(ForeignKey("rooms.id"), nullable=False)
+    user_id: Mapped[str] = mapped_column(ForeignKey("users.id"), nullable=False)
+    body: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[dt.datetime] = mapped_column(DateTime, default=dt.datetime.utcnow)
+    edited_at: Mapped[dt.datetime | None] = mapped_column(DateTime, nullable=True)
+
+    room = relationship("Room", back_populates="messages")
+    user = relationship("User", back_populates="messages")

--- a/backend/app/rooms.py
+++ b/backend/app/rooms.py
@@ -1,0 +1,81 @@
+import datetime as dt
+from uuid import uuid4
+
+from flask import Blueprint, g, jsonify, request
+from flask_jwt_extended import get_jwt_identity, jwt_required
+
+from .models import Message, Room
+
+bp = Blueprint("rooms", __name__)
+
+
+def serialize_room(room: Room) -> dict:
+    return {"id": room.id, "name": room.name, "createdAt": room.created_at.isoformat()}
+
+
+def serialize_message(msg: Message) -> dict:
+    return {
+        "id": msg.id,
+        "roomId": msg.room_id,
+        "userId": msg.user_id,
+        "body": msg.body,
+        "createdAt": msg.created_at.isoformat(),
+        "editedAt": msg.edited_at.isoformat() if msg.edited_at else None,
+    }
+
+
+@bp.get("/rooms")
+@jwt_required()
+def list_rooms():
+    session = g.db
+    rooms = session.query(Room).order_by(Room.created_at.asc()).all()
+    return jsonify([serialize_room(r) for r in rooms])
+
+
+@bp.post("/rooms")
+@jwt_required()
+def create_room():
+    data = request.get_json() or {}
+    name = data.get("name")
+    if not name:
+        return jsonify({"message": "Invalid payload"}), 400
+    room = Room(id=str(uuid4()), name=name)
+    session = g.db
+    session.add(room)
+    session.commit()
+    return jsonify(serialize_room(room)), 201
+
+
+@bp.get("/rooms/<room_id>/messages")
+@jwt_required()
+def list_messages(room_id: str):
+    session = g.db
+    query = session.query(Message).filter_by(room_id=room_id)
+    since = request.args.get("since")
+    if since:
+        try:
+            since_dt = dt.datetime.fromisoformat(since)
+            query = query.filter(Message.created_at > since_dt)
+        except ValueError:
+            pass
+    limit = request.args.get("limit", type=int) or 50
+    limit = min(max(limit, 1), 100)
+    messages = query.order_by(Message.created_at.asc()).limit(limit).all()
+    return jsonify([serialize_message(m) for m in messages])
+
+
+@bp.post("/rooms/<room_id>/messages")
+@jwt_required()
+def create_message(room_id: str):
+    data = request.get_json() or {}
+    body = data.get("body")
+    if not body:
+        return jsonify({"message": "Invalid payload"}), 400
+    session = g.db
+    room = session.get(Room, room_id)
+    if not room:
+        return jsonify({"message": "Room not found"}), 404
+    msg = Message(id=str(uuid4()), room_id=room_id, user_id=get_jwt_identity(), body=body)
+    session.add(msg)
+    session.commit()
+    return jsonify(serialize_message(msg)), 201

--- a/backend/migrations/env.py
+++ b/backend/migrations/env.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import os
+import sys
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from backend.app.models import Base, DATABASE_URL
+
+config = context.config
+fileConfig(config.config_file_name)
+
+if not config.get_main_option("sqlalchemy.url"):
+    config.set_main_option("sqlalchemy.url", os.environ.get("DATABASE_URL", DATABASE_URL))
+
+target_metadata = Base.metadata
+
+
+def run_migrations_offline() -> None:
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(url=url, target_metadata=target_metadata, literal_binds=True, dialect_opts={"paramstyle": "named"})
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/backend/migrations/versions/0001_create_tables.py
+++ b/backend/migrations/versions/0001_create_tables.py
@@ -1,0 +1,38 @@
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0001'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+def upgrade() -> None:
+    op.create_table(
+        'users',
+        sa.Column('id', sa.String(), primary_key=True),
+        sa.Column('email', sa.String(), nullable=False, unique=True),
+        sa.Column('password_hash', sa.String(), nullable=False),
+        sa.Column('display_name', sa.String(), nullable=False),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+    )
+    op.create_table(
+        'rooms',
+        sa.Column('id', sa.String(), primary_key=True),
+        sa.Column('name', sa.String(), nullable=False),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+    )
+    op.create_table(
+        'messages',
+        sa.Column('id', sa.String(), primary_key=True),
+        sa.Column('room_id', sa.String(), sa.ForeignKey('rooms.id'), nullable=False),
+        sa.Column('user_id', sa.String(), sa.ForeignKey('users.id'), nullable=False),
+        sa.Column('body', sa.Text(), nullable=False),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+        sa.Column('edited_at', sa.DateTime(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table('messages')
+    op.drop_table('rooms')
+    op.drop_table('users')


### PR DESCRIPTION
## Summary
- add SQLAlchemy models and initial Alembic migration
- implement signup/login, rooms and messages APIs
- extend Socket.IO namespace with room and message events plus JWT auth

## Testing
- `alembic upgrade head`
- `pytest`
- `npm run test:api` *(fails: Missing script)*
- `npm run lint` *(fails: Next.js ESLint plugin prompt)*

------
https://chatgpt.com/codex/tasks/task_e_689a1d5e3bb08327a63088a6b0036fb2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Added user signup and login with JWT authentication.
  * Introduced Rooms API: list/create rooms; list/create messages with pagination and timestamps.
  * Enabled real-time chat: authenticated WebSocket connection, join/leave rooms, typing indicators, message creation, and standardized acknowledgments.

* Chores
  * Added database and migration configuration to support persistent data.
  * Ignored local database file to prevent it from being committed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->